### PR TITLE
feat: add lounge tier color tokens #110

### DIFF
--- a/src/color/brand.json
+++ b/src/color/brand.json
@@ -1543,6 +1543,12 @@
         "deprecated": true,
         "version": "4.5.0",
         "reference": "n/a"
+      },
+      "loungeplus": {
+        "value": "53b390",
+        "public": true,
+        "usage": "Tier branding color",
+        "deprecated": false
       }
     }
   }

--- a/src/color/brand.json
+++ b/src/color/brand.json
@@ -1544,6 +1544,12 @@
         "version": "4.5.0",
         "reference": "n/a"
       },
+      "lounge": {
+        "value": "01426a",
+        "public": true,
+        "usage": "Tier branding color",
+        "deprecated": false
+      },
       "loungeplus": {
         "value": "53b390",
         "public": true,

--- a/src/color/tier.json
+++ b/src/color/tier.json
@@ -73,6 +73,20 @@
               "wcag": "n/a",
               "deprecated": false
             }
+          },
+          "lounge": {
+            "value": "{color.brand.midnight.400.value}",
+            "public": true,
+            "usage": "lounge tier color for Alaska Airlines",
+            "wcag": "n/a",
+            "deprecated": false
+          },
+          "loungeplus": {
+            "value": "{color.brand.loungeplus.value}",
+            "public": true,
+            "usage": "loungeplus tier color for Alaska Airlines",
+            "wcag": "n/a",
+            "deprecated": false
           }
         },
         "fare": {

--- a/src/color/tier.json
+++ b/src/color/tier.json
@@ -75,7 +75,7 @@
             }
           },
           "lounge": {
-            "value": "{color.brand.midnight.400.value}",
+            "value": "{color.brand.lounge.value}",
             "public": true,
             "usage": "lounge tier color for Alaska Airlines",
             "wcag": "n/a",


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Resolves:** #110

## Summary:

- Add color tokens for lounge and lounge plus
- The output will be (following the pattern from `one world` and `alaska elite`): 
```
$ds-color-tier-alaska-lounge: #01426a;
$ds-color-tier-alaska-loungeplus: #53b390;
```

## Type of change:

Please delete options that are not relevant.

- [x] New capability
- [ ] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
