### PR TITLE
docs: remove references to redundant data-aag-theme attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,12 @@ Auro Design Tokens support multiple themes:
 
 ## Theme Scoping
 
-Apply different themes using the `data-aag-theme` attribute:
+### Alaska Air Group Exclusive
 
-```html
-<!-- Alaska-themed -->
-<div data-aag-theme="aag-theme-as">
-  <h1>Alaska Airlines Content</h1>
-</div>
+> [!IMPORTANT]  
+> The following link is only intended for Alaska Air Group employees and is protected by SSO.
 
-<!-- Hawaiian-themed -->
-<div data-aag-theme="aag-theme-ha">
-  <h1>Hawaiian Airlines Content</h1>
-</div>
-```
+- [Prepare your pages for multi-brand theming](https://wiki.devtools.teamaag.com/guides/multibrand)
 
 ## Documentation
 

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -2,15 +2,14 @@
 
 Detailed information about token formats, file types, and implementation patterns to support your development workflow.
 
-## Theme Data Attributes
+## Theme Scoping
 
-For theme scoping with CSS Custom Properties, use the following data attributes:
+### Alaska Air Group Exclusive
 
-| Theme | Data Attribute | Theme Code |
-|-------|---------------|------------|
-| Alaska | `data-aag-theme="aag-theme-as"` | `as` |
-| Alaska Classic | `data-aag-theme="aag-theme-asc"` | `asc` |
-| Hawaiian | `data-aag-theme="aag-theme-ha"` | `ha` |
+> [!IMPORTANT]  
+> The following link is only intended for Alaska Air Group employees and is protected by SSO.
+
+- [Prepare your pages for multi-brand theming](https://wiki.devtools.teamaag.com/guides/multibrand)
 
 ## Theme Resources
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Remove references to redundant `data-aag-theme` attribute, and replace with link to Frontend Guild wiki.

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Documentation:
- Replace detailed theme attribute documentation with a reference to internal Frontend Guild wiki page for multi-brand theming