### PR TITLE
feat: update font token compilation

### DIFF
--- a/src/primitives/base/font.json
+++ b/src/primitives/base/font.json
@@ -227,7 +227,7 @@
         "type": "primitive",
         "value": "400"
       },
-      "semiBold": {
+      "semibold": {
         "deprecated": false,
         "public": false,
         "type": "primitive",

--- a/src/primitives/base/font.json
+++ b/src/primitives/base/font.json
@@ -191,47 +191,47 @@
       }
     },
     "weight": {
-      "300": {
+      "book": {
         "deprecated": false,
         "public": false,
         "type": "primitive",
-        "value": "Light"
+        "value": "450"
       },
-      "400": {
+      "condMedium": {
         "deprecated": false,
         "public": false,
         "type": "primitive",
-        "value": "Regular"
+        "value": "525"
       },
-      "425": {
+      "condNews": {
         "deprecated": false,
         "public": false,
         "type": "primitive",
-        "value": "Cond News"
+        "value": "425"
       },
-      "450": {
+      "light": {
         "deprecated": false,
         "public": false,
         "type": "primitive",
-        "value": "Book"
+        "value": "300"
       },
-      "500": {
+      "medium": {
         "deprecated": false,
         "public": false,
         "type": "primitive",
-        "value": "Medium"
+        "value": "500"
       },
-      "525": {
+      "regular": {
         "deprecated": false,
         "public": false,
         "type": "primitive",
-        "value": "Cond Medium"
+        "value": "400"
       },
-      "600": {
+      "semiBold": {
         "deprecated": false,
         "public": false,
         "type": "primitive",
-        "value": "Semibold"
+        "value": "600"
       }
     }
   }

--- a/src/primitives/base/font.json
+++ b/src/primitives/base/font.json
@@ -201,13 +201,13 @@
         "deprecated": false,
         "public": false,
         "type": "primitive",
-        "value": "525"
+        "value": "500"
       },
       "condNews": {
         "deprecated": false,
         "public": false,
         "type": "primitive",
-        "value": "425"
+        "value": "450"
       },
       "light": {
         "deprecated": false,

--- a/src/themes/alaska-classic/basic/font/accent.json
+++ b/src/themes/alaska-classic/basic/font/accent.json
@@ -24,7 +24,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -61,7 +61,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -98,7 +98,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -139,7 +139,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -176,7 +176,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -213,7 +213,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -254,7 +254,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -291,7 +291,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -328,7 +328,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -369,7 +369,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -406,7 +406,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -443,7 +443,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -484,7 +484,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -521,7 +521,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -558,7 +558,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -599,7 +599,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -636,7 +636,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -673,7 +673,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -714,7 +714,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -751,7 +751,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -788,7 +788,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,

--- a/src/themes/alaska-classic/basic/font/body.json
+++ b/src/themes/alaska-classic/basic/font/body.json
@@ -22,7 +22,7 @@
             "public": true,
             "type": "semantic",
             "usage": "",
-            "value": "{font.weight.450.value}"
+            "value": "{font.weight.book.value}"
           },
           "letterSpacing": {
             "deprecated": false,
@@ -59,7 +59,7 @@
             "public": true,
             "type": "semantic",
             "usage": "",
-            "value": "{font.weight.450.value}"
+            "value": "{font.weight.book.value}"
           },
           "letterSpacing": {
             "deprecated": false,
@@ -96,7 +96,7 @@
             "public": true,
             "type": "semantic",
             "usage": "",
-            "value": "{font.weight.450.value}"
+            "value": "{font.weight.book.value}"
           },
           "letterSpacing": {
             "deprecated": false,
@@ -133,7 +133,7 @@
             "public": true,
             "type": "semantic",
             "usage": "",
-            "value": "{font.weight.450.value}"
+            "value": "{font.weight.book.value}"
           },
           "letterSpacing": {
             "deprecated": false,
@@ -170,7 +170,7 @@
             "public": true,
             "type": "semantic",
             "usage": "",
-            "value": "{font.weight.450.value}"
+            "value": "{font.weight.book.value}"
           },
           "letterSpacing": {
             "deprecated": false,

--- a/src/themes/alaska-classic/basic/font/display.json
+++ b/src/themes/alaska-classic/basic/font/display.json
@@ -24,7 +24,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -61,7 +61,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -98,7 +98,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -139,7 +139,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -176,7 +176,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -213,7 +213,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -254,7 +254,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -291,7 +291,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -328,7 +328,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -369,7 +369,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -406,7 +406,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -443,7 +443,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -484,7 +484,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -521,7 +521,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -558,7 +558,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -599,7 +599,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -636,7 +636,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -673,7 +673,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,

--- a/src/themes/alaska-classic/basic/font/heading.json
+++ b/src/themes/alaska-classic/basic/font/heading.json
@@ -24,7 +24,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -61,7 +61,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -98,7 +98,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -139,7 +139,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -176,7 +176,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -213,7 +213,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -254,7 +254,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -291,7 +291,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -328,7 +328,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -369,7 +369,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -406,7 +406,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -443,7 +443,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -484,7 +484,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -521,7 +521,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -558,7 +558,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -599,7 +599,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -636,7 +636,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -673,7 +673,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,

--- a/src/themes/alaska/basic/font/accent.json
+++ b/src/themes/alaska/basic/font/accent.json
@@ -24,7 +24,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.425.value}"
+                "value": "{font.weight.condNews.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -61,7 +61,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.425.value}"
+                "value": "{font.weight.condNews.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -98,7 +98,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.425.value}"
+                "value": "{font.weight.condNews.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -139,7 +139,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -176,7 +176,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -213,7 +213,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -254,7 +254,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -291,7 +291,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -328,7 +328,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -369,7 +369,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.425.value}"
+                "value": "{font.weight.condNews.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -406,7 +406,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.425.value}"
+                "value": "{font.weight.condNews.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -443,7 +443,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.425.value}"
+                "value": "{font.weight.condNews.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -484,7 +484,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -521,7 +521,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -558,7 +558,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.525.value}"
+                "value": "{font.weight.condMedium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -599,7 +599,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.425.value}"
+                "value": "{font.weight.condNews.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -636,7 +636,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.425.value}"
+                "value": "{font.weight.condNews.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -673,7 +673,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.425.value}"
+                "value": "{font.weight.condNews.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -714,7 +714,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.425.value}"
+                "value": "{font.weight.condNews.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -751,7 +751,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.425.value}"
+                "value": "{font.weight.condNews.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -788,7 +788,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.425.value}"
+                "value": "{font.weight.condNews.value}"
               },
               "letterSpacing": {
                 "deprecated": false,

--- a/src/themes/alaska/basic/font/body.json
+++ b/src/themes/alaska/basic/font/body.json
@@ -22,7 +22,7 @@
             "public": true,
             "type": "semantic",
             "usage": "",
-            "value": "{font.weight.450.value}"
+            "value": "{font.weight.book.value}"
           },
           "letterSpacing": {
             "deprecated": false,
@@ -59,7 +59,7 @@
             "public": true,
             "type": "semantic",
             "usage": "",
-            "value": "{font.weight.450.value}"
+            "value": "{font.weight.book.value}"
           },
           "letterSpacing": {
             "deprecated": false,
@@ -96,7 +96,7 @@
             "public": true,
             "type": "semantic",
             "usage": "",
-            "value": "{font.weight.450.value}"
+            "value": "{font.weight.book.value}"
           },
           "letterSpacing": {
             "deprecated": false,
@@ -133,7 +133,7 @@
             "public": true,
             "type": "semantic",
             "usage": "",
-            "value": "{font.weight.450.value}"
+            "value": "{font.weight.book.value}"
           },
           "letterSpacing": {
             "deprecated": false,
@@ -170,7 +170,7 @@
             "public": true,
             "type": "semantic",
             "usage": "",
-            "value": "{font.weight.450.value}"
+            "value": "{font.weight.book.value}"
           },
           "letterSpacing": {
             "deprecated": false,

--- a/src/themes/alaska/basic/font/display.json
+++ b/src/themes/alaska/basic/font/display.json
@@ -24,7 +24,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -61,7 +61,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -98,7 +98,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -139,7 +139,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -176,7 +176,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -213,7 +213,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -254,7 +254,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -291,7 +291,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -328,7 +328,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -369,7 +369,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -406,7 +406,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -443,7 +443,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -484,7 +484,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -521,7 +521,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -558,7 +558,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -599,7 +599,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -636,7 +636,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -673,7 +673,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,

--- a/src/themes/alaska/basic/font/heading.json
+++ b/src/themes/alaska/basic/font/heading.json
@@ -24,7 +24,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -61,7 +61,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -98,7 +98,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -139,7 +139,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -176,7 +176,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -213,7 +213,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -254,7 +254,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -291,7 +291,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -328,7 +328,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -369,7 +369,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -406,7 +406,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -443,7 +443,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.300.value}"
+                "value": "{font.weight.light.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -484,7 +484,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -521,7 +521,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -558,7 +558,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -599,7 +599,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -636,7 +636,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -673,7 +673,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.450.value}"
+                "value": "{font.weight.book.value}"
               },
               "letterSpacing": {
                 "deprecated": false,

--- a/src/themes/hawaiian/basic/font/accent.json
+++ b/src/themes/hawaiian/basic/font/accent.json
@@ -24,7 +24,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -61,7 +61,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -98,7 +98,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -139,7 +139,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -176,7 +176,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -213,7 +213,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -254,7 +254,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -291,7 +291,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -328,7 +328,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -369,7 +369,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -406,7 +406,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -443,7 +443,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -484,7 +484,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -521,7 +521,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -558,7 +558,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -599,7 +599,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -636,7 +636,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -673,7 +673,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -714,7 +714,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -751,7 +751,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -788,7 +788,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,

--- a/src/themes/hawaiian/basic/font/body.json
+++ b/src/themes/hawaiian/basic/font/body.json
@@ -22,7 +22,7 @@
             "public": true,
             "type": "semantic",
             "usage": "",
-            "value": "{font.weight.400.value}"
+            "value": "{font.weight.regular.value}"
           },
           "letterSpacing": {
             "deprecated": false,
@@ -59,7 +59,7 @@
             "public": true,
             "type": "semantic",
             "usage": "",
-            "value": "{font.weight.400.value}"
+            "value": "{font.weight.regular.value}"
           },
           "letterSpacing": {
             "deprecated": false,
@@ -96,7 +96,7 @@
             "public": true,
             "type": "semantic",
             "usage": "",
-            "value": "{font.weight.400.value}"
+            "value": "{font.weight.regular.value}"
           },
           "letterSpacing": {
             "deprecated": false,
@@ -133,7 +133,7 @@
             "public": true,
             "type": "semantic",
             "usage": "",
-            "value": "{font.weight.400.value}"
+            "value": "{font.weight.regular.value}"
           },
           "letterSpacing": {
             "deprecated": false,
@@ -170,7 +170,7 @@
             "public": true,
             "type": "semantic",
             "usage": "",
-            "value": "{font.weight.400.value}"
+            "value": "{font.weight.regular.value}"
           },
           "letterSpacing": {
             "deprecated": false,

--- a/src/themes/hawaiian/basic/font/display.json
+++ b/src/themes/hawaiian/basic/font/display.json
@@ -24,7 +24,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -61,7 +61,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -98,7 +98,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -139,7 +139,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -176,7 +176,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -213,7 +213,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -254,7 +254,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -291,7 +291,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -328,7 +328,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -369,7 +369,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -406,7 +406,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -443,7 +443,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -484,7 +484,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -521,7 +521,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -558,7 +558,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -599,7 +599,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -636,7 +636,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -673,7 +673,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.600.value}"
+                "value": "{font.weight.semibold.value}"
               },
               "letterSpacing": {
                 "deprecated": false,

--- a/src/themes/hawaiian/basic/font/heading.json
+++ b/src/themes/hawaiian/basic/font/heading.json
@@ -24,7 +24,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -61,7 +61,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -98,7 +98,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -139,7 +139,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -176,7 +176,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -213,7 +213,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -254,7 +254,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -291,7 +291,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -328,7 +328,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -369,7 +369,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -406,7 +406,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -443,7 +443,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.400.value}"
+                "value": "{font.weight.regular.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -484,7 +484,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -521,7 +521,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -558,7 +558,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -599,7 +599,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -636,7 +636,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,
@@ -673,7 +673,7 @@
                 "public": true,
                 "type": "semantic",
                 "usage": "",
-                "value": "{font.weight.500.value}"
+                "value": "{font.weight.medium.value}"
               },
               "letterSpacing": {
                 "deprecated": false,


### PR DESCRIPTION
# Alaska Airlines Pull Request

**New Features:**

- Add custom transform to automatically quote font family names in Style Dictionary

**Enhancements:**

- Reverse `fontWeight` tokens to compile valid CSS.

Previously:

```
"300": {
  "type": "primitive",
  "value": "Light"
},
```

When compiled to CSS it creates: `font-weight: Light` which is not valid.

Updated:

```
"light": {
  "type": "primitive",
  "value": "300"
},
```

Which compiles to valid css: `font-weight: 300`

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Update Style Dictionary configuration to improve font token compilation and handling

New Features:
- Add custom transform to automatically quote font family names in Style Dictionary

Enhancements:
- Modify Style Dictionary transform groups to handle font family tokens
- Update configuration to automatically add quotes to font family names