### PR TITLE
fix: numerical sass values should not be in quotes

### DIFF
--- a/scripts/styleDictionary.mjs
+++ b/scripts/styleDictionary.mjs
@@ -62,17 +62,22 @@ const fontFamilyTransform = {
   /** 
    * Matches type tokens that are related to font families.
    * 
-   * 1. Checks if token is categorized as 'font' or 'type'
-   * 2. Checks token path for 'family' combined with 'font'/'type'
+   * 1. Checks if token is categorized as 'font'
+   * 2. Checks if token is categorized as 'type' AND has 'family' in the path
+   * 3. Checks token path for 'family' combined with 'font'/'type'
    * 
    * @param {Object} prop - The token property
    * @returns {boolean} - Returns true if the property matches the font-family criteria, otherwise false
    */
   matcher: (prop) => {
-    // Primary check: explicit font/type category attribute
-    // Auro Classic uses 'font' while v6 & greater themes uses 'type'
-    const hasTypeCategoryAttr = prop.attributes && 
-      (prop.attributes.category === 'font' || prop.attributes.category === 'type');
+    // Check for font category (used in Auro Classic)
+    const hasFontCategory = prop.attributes && prop.attributes.category === 'font';
+    
+    // Check for type category WITH family in path - avoids matching numerical values
+    const hasTypeAndFamilyPath = prop.attributes && 
+      prop.attributes.category === 'type' && 
+      prop.path && 
+      prop.path.includes('family');
     
     // Catches tokens that might not have explicit categories but follow naming conventions
     // Only matches 'family' when it appears alongside 'type' or 'font' in the path
@@ -86,7 +91,7 @@ const fontFamilyTransform = {
       prop.path.some(segment => segment.toLowerCase().includes('family'));
     
     // Return true if any condition is met
-    return hasTypeCategoryAttr || isFontFamilyPath || isBrandFontFamily;
+    return hasFontCategory || hasTypeAndFamilyPath || isFontFamilyPath || isBrandFontFamily;
   },
   /** 
    * @param {Object} prop


### PR DESCRIPTION
# Alaska Airlines Pull Request

Numerical SASS values were being compiled with quotes:

**Before:**

```
$ds-basic-type-letter-spacing-heading: "0";
$ds-basic-type-line-height-accent: "1.3";
```

**After:**

```
$ds-basic-type-letter-spacing-heading: 0;
$ds-basic-type-line-height-accent: 1.3;
```

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
